### PR TITLE
Update Gatsby benchmark to not transpile node_modules for IE

### DIFF
--- a/gatsby/package.json
+++ b/gatsby/package.json
@@ -15,6 +15,7 @@
     "clean": "gatsby clean",
     "typecheck": "tsc --noEmit"
   },
+  "browserlist": [">0.25%", "not dead", "supports es6-module"]
   "dependencies": {
     "gatsby": "^4.12.1",
     "gatsby-source-filesystem": "^4.12.1",


### PR DESCRIPTION
Check impact of https://github.com/gatsbyjs/gatsby/pull/35702